### PR TITLE
add rank and file labels

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -701,17 +701,21 @@ function drawRankAndFileLabels(
   files: string[],
 ) {
   const boxSize = (rect.width / GRID_DIM);
+  const fontSize = Math.round(boxSize / 5);
+  if (fontSize < 8) return;
+  const yOffset = boxSize / 4;
+  const xOffset = -boxSize / 4;
   ctx.fillStyle = '#ccc';
-  ctx.font = 'medium 12px sans-serif';
+  ctx.font = `normal ${fontSize}px sans-serif`;
   ranks.forEach((rank, i) => {
     const textWidth = ctx.measureText(rank).width;
     const x = rect.x + (i * boxSize) + (boxSize / 2) - (textWidth / 2);
-    ctx.fillText(rank, x, rect.y + rect.height + 12);
+    ctx.fillText(rank, x, rect.y + rect.height + yOffset);
   });
   files.forEach((file, i) => {
-    const textHeight = 7; // ≈ ctx.measureText(file).actualBoundingBoxAscent;
+    const textHeight = ctx.measureText(file).actualBoundingBoxAscent;
     const y = rect.y + (i * boxSize) + (boxSize / 2) + (textHeight / 2);
-    ctx.fillText(file, rect.x - 10, y);
+    ctx.fillText(file, rect.x + xOffset, y);
   });
 }
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -44,6 +44,8 @@ export function updateAndDraw(
 
   drawBoardBackground(ctx, BOARD_1_RECT);
   drawBoardBackground(ctx, BOARD_2_RECT);
+  drawRankAndFileLabels(ctx, BOARD_1_RECT, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], ['8', '7', '6', '5', '4', '3', '2', '1']);
+  drawRankAndFileLabels(ctx, BOARD_2_RECT, ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a'], ['1', '2', '3', '4', '5', '6', '7', '8']);
   drawOpponentSelected(ctx, playerRight.selected, "white", BOARD_1_RECT);
   drawOpponentSelected(ctx, playerLeft.selected, "black", BOARD_2_RECT);
   drawSelected(ctx, playerLeft.selected, "white", BOARD_1_RECT);
@@ -690,6 +692,27 @@ function drawBoardBackground(
       ctx.fillRect(x0, y0, x1 - x0, y1 - y0);
     }),
   );
+}
+
+function drawRankAndFileLabels(
+  ctx: CanvasRenderingContext2D,
+  rect: { x: number; y: number; width: number; height: number },
+  ranks: string[],
+  files: string[],
+) {
+  const boxSize = (rect.width / GRID_DIM);
+  ctx.fillStyle = '#ccc';
+  ctx.font = 'medium 12px sans-serif';
+  ranks.forEach((rank, i) => {
+    const textWidth = ctx.measureText(rank).width;
+    const x = rect.x + (i * boxSize) + (boxSize / 2) - (textWidth / 2);
+    ctx.fillText(rank, x, rect.y + rect.height + 12);
+  });
+  files.forEach((file, i) => {
+    const textHeight = 7; // ≈ ctx.measureText(file).actualBoundingBoxAscent;
+    const y = rect.y + (i * boxSize) + (boxSize / 2) + (textHeight / 2);
+    ctx.fillText(file, rect.x - 10, y);
+  });
 }
 
 function drawPieces(

--- a/src/state.ts
+++ b/src/state.ts
@@ -42,7 +42,7 @@ export const startingPieces: {
 ];
 
 const initialGameState = {
-  state: "playing" as "readyUp" | "playing",
+  state: "readyUp" as "readyUp" | "playing",
   pieces: structuredClone(startingPieces).map((piece) => ({
     ...piece,
     cooldownRemaining: 0,

--- a/src/state.ts
+++ b/src/state.ts
@@ -42,7 +42,7 @@ export const startingPieces: {
 ];
 
 const initialGameState = {
-  state: "readyUp" as "readyUp" | "playing",
+  state: "playing" as "readyUp" | "playing",
   pieces: structuredClone(startingPieces).map((piece) => ({
     ...piece,
     cooldownRemaining: 0,


### PR DESCRIPTION
not sure if this is in line with your vision or if it's just visual noise but I noticed when we were working on castling that I was really slow to describe which square I was talking about--so maybe having these labels would help spectators, too?

curious what you think!

<img width="858" alt="Screenshot 2024-06-20 at 19 51 44" src="https://github.com/onsclom/async-chess/assets/2024396/80055533-bef5-49cf-a078-cd98212fac86">
